### PR TITLE
Remove content type from POST request

### DIFF
--- a/src/features/experience/AddEditExperienceComponent.js
+++ b/src/features/experience/AddEditExperienceComponent.js
@@ -49,9 +49,6 @@ function AddEditExperienceComponent({
     }
 
     fetch(`${API_URL}/resume/experience`, {
-      headers: {
-        "Content-Type": "application/json",
-      },
       method: "POST",
       body: data,
     })


### PR DESCRIPTION
This is part 1 of the bugfix for adding new experiences, and it's the simpler part. Content-type: application/json is wrong here, since we're not sending json, but multipart form data. I initially changed it to multipart/form-data, but that was wrong! It turns out you need to add the boundary to the header, and the correct solution is to leave it off completely so react can do it properly by itself!

I will now fix it in the python application, so it reads the data properly.